### PR TITLE
Add GPT2 model

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -16,6 +16,7 @@ makedocs(sitename="Transformers.jl",
            "Pretrain" => "pretrain.md",
            "Models" => [
              "GPT" => "gpt.md",
+             "GPT-2" => "gpt2.md",
              "BERT" => "bert.md",
            ],
            "Datasets" => "datasets.md"

--- a/docs/src/gpt2.md
+++ b/docs/src/gpt2.md
@@ -1,0 +1,10 @@
+# Transformers.GenerativePreTrain2
+Implementation of the GPT-2 model.
+
+
+## API reference
+
+```@autodocs
+Modules=[Transformers.GenerativePreTrain2]
+Order = [:type, :function, :macro]
+```

--- a/src/Transformers.jl
+++ b/src/Transformers.jl
@@ -11,6 +11,7 @@ export dataset, datafile, get_batch, get_vocab
 
 export todevice, enable_gpu
 export Gpt
+export Gpt2
 export Bert
 
 const Abstract3DTensor{T} = AbstractArray{T, 3}
@@ -69,6 +70,7 @@ include("./datasets/Datasets.jl")
 include("./pretrain/Pretrain.jl")
 
 include("./gpt/GenerativePreTrain.jl")
+include("./gpt2/GenerativePreTrain2.jl")
 include("./bert/BidirectionalEncoder.jl")
 
 include("./huggingface/HuggingFace.jl")
@@ -78,6 +80,7 @@ using .Stacks
 using .Datasets
 using .Pretrain
 using .GenerativePreTrain
+using .GenerativePreTrain2
 using .BidirectionalEncoder
 
 using .HuggingFace

--- a/src/gpt2/GenerativePreTrain2.jl
+++ b/src/gpt2/GenerativePreTrain2.jl
@@ -1,0 +1,12 @@
+module GenerativePreTrain2
+
+using Flux
+
+using ..Transformers
+using ..Basic
+
+export Gpt2
+
+include("gpt2.jl")
+
+end

--- a/src/gpt2/gpt2.jl
+++ b/src/gpt2/gpt2.jl
@@ -1,0 +1,124 @@
+using Flux: @functor
+
+using ..Basic: AbstractTransformer, MultiheadAttention, PwFFN
+using ..Stacks
+
+struct Gpt2Transformer{A<:MultiheadAttention, L<:LayerNorm, F<:PwFFN} <: AbstractTransformer
+    pre_norm::L
+    attention::A
+    attn_norm::L
+    piecewise::F
+end
+
+@functor Gpt2Transformer
+
+"""
+    Gpt2Transformer(inputsize::Integer, num_heads::Integer,
+                    ffhiddensize::Integer; look_ahead::Bool = false, activation = gelu)
+    Gpt2Transformer(inputsize::Integer, num_heads::Integer, attnhiddensize::Integer,
+                    ffhiddensize::Integer; look_ahead::Bool = false, activation = gelu)
+
+Modified transformer layer for the [`Gpt2`](@ref) model.
+Very similar to a standard [`Transformer`](@ref).
+
+If `attnhiddensize` is not specified, use `div(size, head)` as the hidden size
+of multi-head attention.
+`activation` is the activation function of the positionwise feedforward layer.
+When `look_ahead` is `false`, the k-th token can't see the j-th tokens where j > k.
+"""
+function Gpt2Transformer(inputsize::Integer, num_heads::Integer, ffhiddensize::Integer;
+                         look_ahead::Bool=false, activation=gelu)
+    if inputsize % num_heads != 0
+        throw(ArgumentError("`inputsize` not divisible by `num_heads`"))
+    end
+    Gpt2Transformer(inputsize, num_heads, div(inputsize, num_heads), ffhiddensize;
+                    look_ahead=look_ahead, activation=activation)
+end
+
+function Gpt2Transformer(inputsize::Integer, heads::Integer, attnhiddensize::Integer,
+                         ffhiddensize::Integer; look_ahead::Bool=false, activation=gelu)
+    Gpt2Transformer(
+        LayerNorm(inputsize),
+        MultiheadAttention(heads, inputsize, attnhiddensize, inputsize;
+                           future=look_ahead, pdrop=0),
+        LayerNorm(inputsize),
+        PwFFN(inputsize, ffhiddensize, activation),
+    )
+end
+
+function (b::Gpt2Transformer)(input::AbstractArray{T, N}, mask=nothing) where {T, N}
+    normed_input = b.pre_norm(input)::typeof(input)
+    attn = b.attention(normed_input, normed_input, normed_input; mask=mask)
+    res_attn = input .+ attn
+    if N == 3
+        insize = size(res_attn)
+        res_attn = reshape(res_attn, insize[1], :)
+    end
+    normed_res_attn = b.attn_norm(res_attn)::typeof(res_attn)
+    pwffn = b.piecewise(normed_res_attn)
+    res_pwffn = res_attn .+ pwffn
+    if N == 3
+        res_pwffn = reshape(res_pwffn, :, Base.tail(insize)...)
+    end
+    res_pwffn
+end
+
+
+struct Gpt2{S<:Stack, L<:LayerNorm} <: AbstractTransformer
+    blocks::S
+    final_norm::L
+end
+
+@functor Gpt2
+
+"""
+    Gpt2(inputsize::Integer, num_heads::Integer, ffhiddensize::Integer,
+         num_layers::Integer; activation = gelu)
+    Gpt2(inputsize::Integer, num_heads::Integer, hs::Integer, ffhiddensize::Integer,
+         num_layers::Integer; activation = gelu)
+
+Second version of the Generative Pre-trained Transformer model ([GPT-2](https://cdn.openai.com/better-language-models/language_models_are_unsupervised_multitask_learners.pdf)).
+
+See also: [`Gpt`](@ref)
+"""
+function Gpt2(inputsize::Integer, num_heads::Integer, ffhiddensize::Integer,
+              num_layers::Integer; activation=gelu)
+    if inputsize % num_heads != 0
+        throw(ArgumentError("`inputsize` not divisible by `num_heads`"))
+    end
+    Gpt2(inputsize, num_heads, div(inputsize, num_heads), ffhiddensize, num_layers;
+         activation=activation)
+end
+
+function Gpt2(inputsize::Integer, num_heads::Integer, attnhiddensize::Integer,
+              ffhiddensize::Integer, num_layers::Integer; activation=gelu)
+    Gpt2(
+        Stack(
+            @nntopo_str("x':x => $num_layers"),
+            [
+                Gpt2Transformer(inputsize, num_heads, attnhiddensize, ffhiddensize;
+                                look_ahead=false, activation=activation)
+                for _ in 1:num_layers
+            ]...
+        ),
+        LayerNorm(inputsize)
+    )
+end
+
+"""
+    (gpt::Gpt2)(input, mask=nothing; return_all_outputs::Bool=false)
+
+Evaluate the GPT-2 model on the given `input`. If `mask` is given (of shape
+`(1, seq_len, batch_size)`), mask the attention with it.
+Set `return_all_outputs` to `true` to get all outputs of each internal transformer layer.
+"""
+function (gpt::Gpt2)(input, mask=nothing; return_all_outputs::Bool=false)
+    output, all_outputs = gpt.blocks(input)
+    output = gpt.final_norm(output)
+    isnothing(mask) || (output .*= mask)
+    if return_all_outputs
+        return output, all_outputs
+    else
+        return output  # size(output) == (inputsize, seq_len, batch_len)
+    end
+end

--- a/test/gpt2/transformer.jl
+++ b/test/gpt2/transformer.jl
@@ -1,0 +1,32 @@
+@testset "Transformer" begin
+  gpt = Gpt2(300, 10, 500, 3)
+
+  x = randn(Float32, 300, 5, 2)
+  x1 = x[:,:,1]
+
+  y = gpt(x)
+  y1 = gpt(x1)
+
+  @test size(y) == (300, 5, 2)
+  @test size(y1) == (300, 5)
+  @test y[:,:,1] ≈ y1
+
+  _, yall = gpt(x; return_all_outputs=true)
+  @test gpt.blocks.models[1](x) ≈ yall[1]
+  @test gpt.blocks.models[2](yall[1]) ≈ yall[2]
+  @test gpt.blocks.models[3](yall[2]) ≈ yall[3]
+
+  _, yall1 = gpt(x1; return_all_outputs=true)
+  @test gpt.blocks.models[1](x1) ≈ yall1[1]
+  @test gpt.blocks.models[2](yall1[1]) ≈ yall1[2]
+  @test gpt.blocks.models[3](yall1[2]) ≈ yall1[3]
+
+
+  mask = cat(reshape([1,1,1,1,1], 1, 5, 1),
+             reshape([1,1,1,0,0], 1, 5, 1); dims=3)
+  amask = getmask(mask, mask)
+
+  ym, ymall = gpt(x, mask; return_all_outputs=true)
+  topo = @nntopo ((x, m) => x:(x, m)) => 3
+  @test topo(gpt.blocks.models, x, amask) .* mask ≈ ym
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -12,6 +12,7 @@ const tests = [
     "embed",
     "basic",
     "gpt",
+    "gpt2",
     "bert",
 ]
 

--- a/test/test_gpt2.jl
+++ b/test/test_gpt2.jl
@@ -1,0 +1,6 @@
+@testset "Gpt2" begin
+  using Transformers.GenerativePreTrain2
+  for f ∈ readdir("./gpt2/")
+    include("./gpt2/$f")
+  end
+end


### PR DESCRIPTION
I ported this from another project for which I used an older Flux version (still with `@treelike` and without Zygote). Sadly, I am not able to run the test suite as I am getting CUDA segfaults even without the tests I added (I listed the stacktrace below; this is probably an issue on my part). However, manually executing the test file reveals the same error the old `Gpt` model also has (the very last test fails).

I still have to document the methods but maybe you can already give me some feedback. I have _not_ added support for pre-trained models but maybe I can do that in the future as well. No promises, though. :)

```julia
(Transformers) pkg> test Transformers
   Testing Transformers
 Resolving package versions...
[ Info: Test CUDA
[ Info: Testing CUDA

signal (11): Segmentation fault
in expression starting at /home/jan/.julia/dev/Transformers/test/cuda/gather.jl:1
_ZN4llvm15ValueHandleBase12AddToUseListEv at /home/jan/Downloads/julia-1.3.1/bin/../lib/julia/l
ibLLVM-6.0.so (unknown line)
_ZNSt6vectorIN4llvm14WeakTrackingVHESaIS1_EE12emplace_backIJRPNS0_5ValueEEEEvDpOT_ at /home/jan
/Downloads/julia-1.3.1/bin/../lib/julia/libLLVM-6.0.so (unknown line)
double free or corruption (out)

signal (6): Aborted
in expression starting at /home/jan/.julia/dev/Transformers/test/cuda/gather.jl:1
```