### PR TITLE
Remove const from vocab for AttentionIsAllYouNeed example

### DIFF
--- a/example/AttentionIsAllYouNeed/1-model.jl
+++ b/example/AttentionIsAllYouNeed/1-model.jl
@@ -14,9 +14,10 @@ using Transformers.Basic
 using Random
 Random.seed!(0)
 
+
 include("./0-data.jl")
 
-const vocab = Vocabulary(labels, unksym)
+vocab = Vocabulary(labels, unksym)
 const embed = todevice(Embed(512, length(vocab); scale=inv(sqrt(512))))
 
 const encoder = todevice(Stack(


### PR DESCRIPTION
When const is there. the following error results when trying to run the example with tasks other than the task example. Removing the const allows the example to run.

```
$ julia --project example/AttentionIsAllYouNeed/1-model.jl -g wmt14
ERROR: LoadError: cannot declare vocab constant; it already has a value
Stacktrace:                                       
 [1] top-level scope at .../Transformers.jl/example/AttentionIsAllYouNeed/1-model.jl:19
 [2] include(::Function, ::Module, ::String) at ./Base.jl:380
 [3] include(::Module, ::String) at ./Base.jl:368                                                    
 [4] exec_options(::Base.JLOptions) at ./client.jl:296
 [5] _start() at ./client.jl:506
in expression starting at .../Transformers.jl/example/AttentionIsAllYouNeed/1-model.jl:19
```