### PR TITLE
Fix download links, hashes for glue data

### DIFF
--- a/src/datasets/glue/cola.jl
+++ b/src/datasets/glue/cola.jl
@@ -5,7 +5,7 @@ cola_init() = register(DataDep(
     """
     The Corpus of Linguistic Acceptability (CoLA) task (GLUE version)
     """,
-    "https://firebasestorage.googleapis.com/v0/b/mtl-sentence-representations.appspot.com/o/data%2FCoLA.zip?alt=media&token=46d5e637-3411-4188-bc44-5809b5bfb5f4",
+    "https://dl.fbaipublicfiles.com/glue/data/CoLA.zip",
     "f212fcd832b8f7b435fb991f101abf89f96b933ab400603bf198960dfc32cbff";
     post_fetch_method = fn -> begin
       mv(fn, "CoLA.zip")

--- a/src/datasets/glue/mnli.jl
+++ b/src/datasets/glue/mnli.jl
@@ -5,7 +5,7 @@ mnli_init() = register(DataDep(
     """
      The Multi-Genre Natural Language Inference (MNLI) task (GLUE version)
     """,
-    "https://firebasestorage.googleapis.com/v0/b/mtl-sentence-representations.appspot.com/o/data%2FMNLI.zip?alt=media&token=50329ea1-e339-40e2-809c-10c40afff3ce",
+    "https://dl.fbaipublicfiles.com/glue/data/MNLI.zip",
     "e7c1d896d26ed6caf700110645df426cc2d8ebf02a5ab743d5a5c68ac1c83633";
     post_fetch_method = fn -> begin
       mv(fn, "MNLI.zip")

--- a/src/datasets/glue/qnli.jl
+++ b/src/datasets/glue/qnli.jl
@@ -5,7 +5,7 @@ qnli_init() = register(DataDep(
     """
     Question NLI (SQuAD2.0 / QNLI) task (GLUE version)
     """,
-    "https://firebasestorage.googleapis.com/v0/b/mtl-sentence-representations.appspot.com/o/data%2FQNLIv2.zip?alt=media&token=6fdcf570-0fc5-4631-8456-9505272d1601",
+    "https://dl.fbaipublicfiles.com/glue/data/QNLIv2.zip",
     "e634e78627a29adaecd4f955359b22bf5e70f2cbd93b493f2d624138a0c0e5f5";
     post_fetch_method = fn -> begin
       mv(fn, "QNLIv2.zip")

--- a/src/datasets/glue/qqp.jl
+++ b/src/datasets/glue/qqp.jl
@@ -5,11 +5,11 @@ qqp_init() = register(DataDep(
     """
     Quora Question Pairs (QQP) task (GLUE version)
     """,
-    "https://firebasestorage.googleapis.com/v0/b/mtl-sentence-representations.appspot.com/o/data%2FQQP.zip?alt=media&token=700c6acf-160d-4d89-81d1-de4191d02cb5",
-    "67cb8f5fe66c90a0bc1bf5792e3924f63008b064ab7a473736c919d20bb140ad";
+    "https://dl.fbaipublicfiles.com/glue/data/QQP-clean.zip",
+    "40e7c862c04eb26ee04b67fd900e76c45c6ba8e6d8fab4f8f1f8072a1a3fbae0";
     post_fetch_method = fn -> begin
-      mv(fn, "QQP.zip")
-      DataDeps.unpack("QQP.zip")
+      mv(fn, "QQP-clean.zip")
+      DataDeps.unpack("QQP-clean.zip")
       innerdir = "QQP"
       innerfiles = readdir(innerdir)
       mv.(joinpath.(innerdir, innerfiles), innerfiles)

--- a/src/datasets/glue/rte.jl
+++ b/src/datasets/glue/rte.jl
@@ -5,7 +5,7 @@ rte_init() = register(DataDep(
     """
     Recognizing Textual Entailment (RTE) task (GLUE version)
     """,
-    "https://firebasestorage.googleapis.com/v0/b/mtl-sentence-representations.appspot.com/o/data%2FRTE.zip?alt=media&token=5efa7e85-a0bb-4f19-8ea2-9e1840f077fb",
+    "https://dl.fbaipublicfiles.com/glue/data/RTE.zip",
     "6bf86de103ecd335f3441bd43574d23fef87ecc695977a63b82d5efb206556ee";
     post_fetch_method = fn -> begin
       mv(fn, "RTE.zip")

--- a/src/datasets/glue/sst.jl
+++ b/src/datasets/glue/sst.jl
@@ -5,7 +5,7 @@ sst_init() = register(DataDep(
     """
     The Stanford Sentiment Treebank (SST) task (GLUE version)
     """,
-    "https://firebasestorage.googleapis.com/v0/b/mtl-sentence-representations.appspot.com/o/data%2FSST-2.zip?alt=media&token=aabc5f6b-e466-44a2-b9b4-cf6337f84ac8",
+    "https://dl.fbaipublicfiles.com/glue/data/SST-2.zip",
     "d67e16fb55739c1b32cdce9877596db1c127dc322d93c082281f64057c16deaa";
     post_fetch_method = fn -> begin
       mv(fn, "SST-2.zip")

--- a/src/datasets/glue/sts.jl
+++ b/src/datasets/glue/sts.jl
@@ -5,7 +5,7 @@ sts_init() = register(DataDep(
     """
      The Semantic Textual Similarity Benchmark (STS) task (GLUE version)
     """,
-    "https://firebasestorage.googleapis.com/v0/b/mtl-sentence-representations.appspot.com/o/data%2FSTS-B.zip?alt=media&token=bddb94a7-8706-4e0d-a694-1109e12273b5",
+    "https://dl.fbaipublicfiles.com/glue/data/STS-B.zip",
     "e60a6393de5a8b5b9bac5020a1554b54e3691f9d600b775bd131e613ac179c85";
     post_fetch_method = fn -> begin
       mv(fn, "STS-B.zip")

--- a/src/datasets/glue/wnli.jl
+++ b/src/datasets/glue/wnli.jl
@@ -5,7 +5,7 @@ wnli_init() = register(DataDep(
     """
     Winograd NLI (WNLI) task (GLUE version)
     """,
-    "https://firebasestorage.googleapis.com/v0/b/mtl-sentence-representations.appspot.com/o/data%2FWNLI.zip?alt=media&token=068ad0a0-ded7-4bd7-99a5-5e00222e0faf",
+    "https://dl.fbaipublicfiles.com/glue/data/WNLI.zip",
     "ae0e8e4d16f4d46d4a0a566ec7ecceccfd3fbfaa4a7a4b4e02848c0f2561ac46";
     post_fetch_method = fn -> begin
       mv(fn, "WNLI.zip")


### PR DESCRIPTION
Download links from HF glue dataset: https://github.com/huggingface/datasets/blob/master/datasets/glue/glue.py