### PR TITLE
addresses issue #92

### DIFF
--- a/src/basic/embeds/position_embed.jl
+++ b/src/basic/embeds/position_embed.jl
@@ -17,10 +17,10 @@ Flux.trainable(pe::PositionEmbedding) = pe.trainable ? (embedding = pe.embedding
 get_value(e::PositionEmbedding, name::Symbol, xs::NamedTuple) = e(first(xs))
 
 function PE(size, pos, i::Int)
-    if rem(i, 2) == 0
-        sin((pos-1)/1e4^((i-2)/size))
+    if rem(i, 2) == 1
+        sin((pos-1)/1e4^((i-1)/size))
     else
-        cos((pos-1)/1e4^((i-1)/size))
+        cos((pos-1)/1e4^((i-2)/size))
     end
 end
 

--- a/src/basic/embeds/position_embed.jl
+++ b/src/basic/embeds/position_embed.jl
@@ -18,9 +18,9 @@ get_value(e::PositionEmbedding, name::Symbol, xs::NamedTuple) = e(first(xs))
 
 function PE(size, pos, i::Int)
     if rem(i, 2) == 0
-        sin(pos/1e4^(i/size))
+        sin((pos-1)/1e4^((i-2)/size))
     else
-        cos(pos/1e4^((i-1)/size))
+        cos((pos-1)/1e4^((i-1)/size))
     end
 end
 


### PR DESCRIPTION

This PR addresses issue #92.

By setting n temporarily to 100, I get the same values as show in [1]:

```
julia> Transformers.Basic.PE.(4,(1:4),(1:4)')                                                                                                                         
4×4 Matrix{Float64}:                                                                                                                                                  
  1.0       0.0       1.0       0.0                                                                                                                                   
  0.540302  0.841471  0.995004  0.0998334                                                                                                                             
 -0.416147  0.909297  0.980067  0.198669                                                                                                                              
 -0.989992  0.14112   0.955336  0.29552                                                                                                                               
```                                             
(but this PR does not touches n and keeps its original value of n = 1e4 😀)

[1] https://machinelearningmastery.com/a-gentle-introduction-to-positional-encoding-in-transformer-models-part-1/