### PR TITLE
fix typos

### DIFF
--- a/src/layers/layer.jl
+++ b/src/layers/layer.jl
@@ -282,7 +282,7 @@ end
 Create a multi-head self attention layer with `head` heads and `head_hidden_size` per head.
 """
 function SelfAttention(head::Int, hidden_size::Int; dropout = nothing, return_score = false, causal = false)
-    @assert rem(hidden_state, head) == 0 "`hidden_size` should be dividible by `head` if `head_hidden_size` is not set"
+    @assert rem(hidden_size, head) == 0 "`hidden_size` should be dividible by `head` if `head_hidden_size` is not set"
     head_hidden_size = div(hidden_size, head)
     return SelfAttention(head, hidden_size, head_hidden_size; dropout, return_score, causal)
 end
@@ -316,7 +316,7 @@ end
 Create a multi-head cross attention layer with `head` heads and `head_hidden_size` per head.
 """
 function CrossAttention(head::Int, hidden_size::Int; dropout = nothing, return_score = false)
-    @assert rem(hidden_state, head) == 0 "`hidden_size` should be dividible by `head` if `head_hidden_size` is not set"
+    @assert rem(hidden_size, head) == 0 "`hidden_size` should be dividible by `head` if `head_hidden_size` is not set"
     head_hidden_size = div(hidden_size, head)
     return CrossAttention(head, hidden_size, head_hidden_size; dropout, return_score)
 end


### PR DESCRIPTION
Fixes
```julia
julia> Layers.SelfAttention(8, 512)
ERROR: UndefVarError: hidden_state not defined
Stacktrace:
 [1] Transformers.Layers.SelfAttention(head::Int64, hidden_size::Int64; dropout::Nothing, return_score::Bool, causal::Bool)
   @ Transformers.Layers ~/.julia/packages/Transformers/nIgPX/src/layers/layer.jl:285
 [2] Transformers.Layers.SelfAttention(head::Int64, hidden_size::Int64)
   @ Transformers.Layers ~/.julia/packages/Transformers/nIgPX/src/layers/layer.jl:284
 [3] top-level scope
   @ REPL[73]:1
 [4] top-level scope
   @ ~/.julia/packages/CUDA/BbliS/src/initialization.jl:52

julia> Layers.CrossAttention(8, 512)
ERROR: UndefVarError: hidden_state not defined
Stacktrace:
 [1] Transformers.Layers.CrossAttention(head::Int64, hidden_size::Int64; dropout::Nothing, return_score::Bool)
   @ Transformers.Layers ~/.julia/packages/Transformers/nIgPX/src/layers/layer.jl:319
 [2] Transformers.Layers.CrossAttention(head::Int64, hidden_size::Int64)
   @ Transformers.Layers ~/.julia/packages/Transformers/nIgPX/src/layers/layer.jl:318
 [3] top-level scope
   @ REPL[74]:1
 [4] top-level scope
   @ ~/.julia/packages/CUDA/BbliS/src/initialization.jl:52

```