### PR TITLE
Fix warnings in tests regarding \eps

### DIFF
--- a/test/loss.jl
+++ b/test/loss.jl
@@ -7,7 +7,7 @@
     using NeuralAttentionlib: LengthMask, RevLengthMask, GenericSequenceMask, getmask, lengths
 
     noagg(x; dims = :) = x
-    _crossentropy(args...; kwargs...) = crossentropy(args...; kwargs..., ϵ = 0f0)
+    _crossentropy(args...; kwargs...) = crossentropy(args...; kwargs..., eps = 0f0)
     function naive_loss_w_mask(ŷ, y, m; lossf = _crossentropy, agg = mean)
         batch = size(ŷ, ndims(ŷ))
         loss = lossf(reshape(ŷ, size(ŷ,1), :), reshape(y, size(y,1), :); dims = 1, agg = noagg)


### PR DESCRIPTION
Address the following warnings in the `] test Transformers` environment:
```
┌ Warning: function crossentropy no longer accepts greek-letter keyword ϵ
│ please use ascii eps instead
│   caller = (::var"#_crossentropy#82"{var"#_crossentropy#29#83"})(::Matrix{Float32}, ::Vararg{Any}; kwargs::Base.Pairs{Symbol, Any, Tuple{Symbol, Symbol}, NamedTuple{(:dims, :agg), Tuple{Int64, var"#noagg#80"{var"#noagg#28#81"}}}}) at loss.jl:10
└ @ Main ~/.julia/packages/Transformers/qhUJm/test/loss.jl:10
┌ Warning: function crossentropy no longer accepts greek-letter keyword ϵ
│ please use ascii eps instead
│   caller = ip:0x0
└ @ Core :-1
```